### PR TITLE
Some objectGUID buffer cause error in escape filter function

### DIFF
--- a/lib/utils/escape-filter-value.js
+++ b/lib/utils/escape-filter-value.js
@@ -31,18 +31,19 @@ function escapeBuffer (buf) {
   for (let i = 0; i < buf.length; i += 1) {
     if (buf[i] >= 0xc0 && buf[i] <= 0xdf) {
       // Represents the first byte in a 2-byte UTF-8 character.
-      result += '\\' + buf[i].toString(16) + '\\' + buf[i + 1].toString(16)
+      console.log("-- use 1", i);
+      result += '\\' + buf[i].toString(16);
+      if(i<15) { result += '\\' + buf[i + 1].toString(16); }  //Only add second byte if exist in buffer
       i += 1
       continue
     }
 
     if (buf[i] >= 0xe0 && buf[i] <= 0xef) {
       // Represents the first byte in a 3-byte UTF-8 character.
-      result += [
-        '\\', buf[i].toString(16),
-        '\\', buf[i + 1].toString(16),
-        '\\', buf[i + 2].toString(16)
-      ].join('')
+      console.log("-- use 2", i);
+      result += '\\' + buf[i].toString(16);
+      if(i<15) { result += '\\' + buf[i + 1].toString(16); }  //Only add second byte if exist in buffer
+      if(i<14) { result += '\\' + buf[i + 2].toString(16); }  //Only add third byte if exist in buffer
       i += 2
       continue
     }
@@ -50,10 +51,12 @@ function escapeBuffer (buf) {
     if (buf[i] <= 31) {
       // It's an ASCII control character so we will straight
       // encode it (excluding the "space" character).
+      console.log("-- use 3", i);
       result += '\\' + buf[i].toString(16).padStart(2, '0')
       continue
     }
 
+    console.log("-- use 4", i);
     const char = String.fromCharCode(buf[i])
     switch (char) {
       case '*': {
@@ -82,7 +85,8 @@ function escapeBuffer (buf) {
       }
 
       default: {
-        result += char
+        //result += char
+        result += '\\' + buf[i].toString(16).padStart(2, '0')
         break
       }
     }

--- a/lib/utils/escape-filter-value.js
+++ b/lib/utils/escape-filter-value.js
@@ -31,7 +31,6 @@ function escapeBuffer (buf) {
   for (let i = 0; i < buf.length; i += 1) {
     if (buf[i] >= 0xc0 && buf[i] <= 0xdf) {
       // Represents the first byte in a 2-byte UTF-8 character.
-      console.log("-- use 1", i);
       result += '\\' + buf[i].toString(16);
       if(i<15) { result += '\\' + buf[i + 1].toString(16); }  //Only add second byte if exist in buffer
       i += 1
@@ -40,7 +39,6 @@ function escapeBuffer (buf) {
 
     if (buf[i] >= 0xe0 && buf[i] <= 0xef) {
       // Represents the first byte in a 3-byte UTF-8 character.
-      console.log("-- use 2", i);
       result += '\\' + buf[i].toString(16);
       if(i<15) { result += '\\' + buf[i + 1].toString(16); }  //Only add second byte if exist in buffer
       if(i<14) { result += '\\' + buf[i + 2].toString(16); }  //Only add third byte if exist in buffer
@@ -51,12 +49,10 @@ function escapeBuffer (buf) {
     if (buf[i] <= 31) {
       // It's an ASCII control character so we will straight
       // encode it (excluding the "space" character).
-      console.log("-- use 3", i);
       result += '\\' + buf[i].toString(16).padStart(2, '0')
       continue
     }
 
-    console.log("-- use 4", i);
     const char = String.fromCharCode(buf[i])
     switch (char) {
       case '*': {
@@ -85,8 +81,7 @@ function escapeBuffer (buf) {
       }
 
       default: {
-        //result += char
-        result += '\\' + buf[i].toString(16).padStart(2, '0')
+        result += char
         break
       }
     }

--- a/lib/utils/escape-filter-value.js
+++ b/lib/utils/escape-filter-value.js
@@ -27,22 +27,22 @@ function escapeFilterValue (toEscape) {
 }
 
 function escapeBuffer (buf) {
-  let bufLen = buf.length;
-  let result = '';
+  const bufLen = buf.byteLength
+  let result = ''
   for (let i = 0; i < buf.length; i += 1) {
     if (buf[i] >= 0xc0 && buf[i] <= 0xdf) {
       // Represents the first byte in a 2-byte UTF-8 character.
-      result += '\\' + buf[i].toString(16);
-      if(i<bufLen-1) { result += '\\' + buf[i + 1].toString(16); }  //Only add second byte if exist in buffer
+      result += '\\' + buf[i].toString(16)
+      if (i < (bufLen - 1)) { result += '\\' + buf[i + 1].toString(16).padStart(2, '0') } // Only add second byte if exist in buffer
       i += 1
       continue
     }
 
     if (buf[i] >= 0xe0 && buf[i] <= 0xef) {
       // Represents the first byte in a 3-byte UTF-8 character.
-      result += '\\' + buf[i].toString(16);
-      if(i<bufLen-1) { result += '\\' + buf[i + 1].toString(16); }  //Only add second byte if exist in buffer
-      if(i<bufLen-2) { result += '\\' + buf[i + 2].toString(16); }  //Only add third byte if exist in buffer
+      result += '\\' + buf[i].toString(16)
+      if (i < (bufLen - 1)) { result += '\\' + buf[i + 1].toString(16).padStart(2, '0') } // Only add second byte if exist in buffer
+      if (i < (bufLen - 2)) { result += '\\' + buf[i + 2].toString(16).padStart(2, '0') } // Only add third byte if exist in buffer
       i += 2
       continue
     }

--- a/lib/utils/escape-filter-value.js
+++ b/lib/utils/escape-filter-value.js
@@ -27,12 +27,13 @@ function escapeFilterValue (toEscape) {
 }
 
 function escapeBuffer (buf) {
-  let result = ''
+  let bufLen = buf.length;
+  let result = '';
   for (let i = 0; i < buf.length; i += 1) {
     if (buf[i] >= 0xc0 && buf[i] <= 0xdf) {
       // Represents the first byte in a 2-byte UTF-8 character.
       result += '\\' + buf[i].toString(16);
-      if(i<15) { result += '\\' + buf[i + 1].toString(16); }  //Only add second byte if exist in buffer
+      if(i<bufLen-1) { result += '\\' + buf[i + 1].toString(16); }  //Only add second byte if exist in buffer
       i += 1
       continue
     }
@@ -40,8 +41,8 @@ function escapeBuffer (buf) {
     if (buf[i] >= 0xe0 && buf[i] <= 0xef) {
       // Represents the first byte in a 3-byte UTF-8 character.
       result += '\\' + buf[i].toString(16);
-      if(i<15) { result += '\\' + buf[i + 1].toString(16); }  //Only add second byte if exist in buffer
-      if(i<14) { result += '\\' + buf[i + 2].toString(16); }  //Only add third byte if exist in buffer
+      if(i<bufLen-1) { result += '\\' + buf[i + 1].toString(16); }  //Only add second byte if exist in buffer
+      if(i<bufLen-2) { result += '\\' + buf[i + 2].toString(16); }  //Only add third byte if exist in buffer
       i += 2
       continue
     }

--- a/lib/utils/escape-filter-value.test.js
+++ b/lib/utils/escape-filter-value.test.js
@@ -84,8 +84,14 @@ tap.test('leaves encoded characters intact', async t => {
   }
 })
 
-tap.test('parse binary data with end byte >0xc0', async t => {
-  const input = Buffer.from([0x30, 0x41, 0x62, 0xd2])
-  const expected = '0Ab\\d2'
+tap.test('handle start of two byte utf-8 character at end of buffer', async t => {
+  const input = Buffer.from([0x30, 0xc2])
+  const expected = '0\\c2'
+  t.equal(escapeFilterValue(input), expected)
+})
+
+tap.test('handle start of three byte utf-8 character at end of buffer', async t => {
+  const input = Buffer.from([0x30, 0xe2])
+  const expected = '0\\e2'
   t.equal(escapeFilterValue(input), expected)
 })

--- a/lib/utils/escape-filter-value.test.js
+++ b/lib/utils/escape-filter-value.test.js
@@ -83,3 +83,9 @@ tap.test('leaves encoded characters intact', async t => {
     t.equal(result, expected[i])
   }
 })
+
+tap.test('parse binary data with end byte >0xc0', async t => {
+  const input = Buffer.from([0x30, 0x41, 0x62, 0xd2])
+  const expected = '0Ab\\d2'
+  t.equal(escapeFilterValue(input), expected)
+})


### PR DESCRIPTION
Search object by objectGUID in MS AD cause error for some GUID buffer.
For example with 2 real GUID :
- <Buffer e4 80 74 d3 3e 27 9c 46 b3 33 a3 5f 07 ff 87 a3> works
- <Buffer 44 29 12 42 1d e1 91 41 98 cc 40 92 51 52 7b df> cause error :
`TypeError: Cannot read properties of undefined (reading 'toString')`

This is caused because GUID buffer is not representing character and sometimes, escape function try to escape 2 or 3 bytes at the last buffer byte.
Fix by checking buffer index before try to add second/third byte.